### PR TITLE
fix: add className to make input 50% width

### DIFF
--- a/src/components/LanguageHeader/LanguageHeader.stories.mdx
+++ b/src/components/LanguageHeader/LanguageHeader.stories.mdx
@@ -48,7 +48,7 @@ The language header can be used as a language selector on top of a form.
 							<p>Selected language: <b>{activeLanguage.key}</b></p>
 						</div>
 					}
-					<MultilanguageField asComponent={TextField} fieldClassName={'col-xs-12 col-sm-5'}/>
+					<MultilanguageField asComponent={TextField} fieldClassName='u-width-50' />
 				</LanguageHeader>
 			)
 		}}

--- a/src/components/MultilanguageField/MultilanguageField.module.scss
+++ b/src/components/MultilanguageField/MultilanguageField.module.scss
@@ -11,3 +11,7 @@
 		color: $grey-dark;
 	}
 }
+
+.u-width-50 {
+	width: 50%;
+}


### PR DESCRIPTION
error message is in the right spot when width is set to 50%, not when using columns