### PR TITLE
Bugfix/tooltip ref

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -7,6 +7,8 @@ import React, {
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 
+import { mergeRefs } from '../../helpers';
+
 import { TooltipTypeMap } from './Tooltip.const';
 import './Tooltip.scss';
 
@@ -14,6 +16,7 @@ const Tooltip = ({
 	children,
 	className,
 	targetRef,
+	tooltipRef = null,
 	container,
 	isVisible,
 	type = TooltipTypeMap.DEFAULT,
@@ -69,7 +72,7 @@ const Tooltip = ({
 		<div
 			className={tooltipClasses}
 			style={styles.popper}
-			ref={popperElement}
+			ref={mergeRefs([popperElement, tooltipRef])}
 			{...attributes.popper}
 		>
 			<div ref={setArrowRef} className="arrow">
@@ -97,6 +100,10 @@ Tooltip.propTypes = {
 		TooltipTypeMap.WHITE,
 	]),
 	targetRef: PropTypes.oneOfType([
+		PropTypes.func,
+		PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+	]).isRequired,
+	tooltipRef: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
 	]).isRequired,

--- a/src/components/Tooltip/Tooltip.test.jsx
+++ b/src/components/Tooltip/Tooltip.test.jsx
@@ -73,4 +73,12 @@ describe('<Tooltip/>', () => {
 		const tooltipNode = queryByText(tooltipText);
 		expect(tooltipNode).toHaveClass(className);
 	});
+
+	it('Should pass a ref to the tooltip element', () => {
+		const tooltipRef = jest.fn();
+		const { queryByText } = renderButtonWithTooltip({ tooltipRef, isVisible: true });
+
+		const tooltipNode = queryByText(tooltipText);
+		expect(tooltipRef).toHaveBeenLastCalledWith(tooltipNode);
+	});
 });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,1 +1,2 @@
+export * from './mergeRefs';
 export * from './typeCheck';

--- a/src/helpers/mergeRefs.js
+++ b/src/helpers/mergeRefs.js
@@ -1,0 +1,12 @@
+import { isNil } from './typeCheck';
+
+export const mergeRefs = (refs) => (value) => {
+	refs.forEach((ref) => {
+		if (typeof ref === 'function') {
+			ref(value);
+		} else if (!isNil(ref)) {
+			// eslint-disable-next-line no-param-reassign
+			ref.current = value;
+		}
+	});
+};


### PR DESCRIPTION
When using onClick instead of the focus/blur events, the tooltip stays open when clicking outside of the element.
The preferable behaviour is that the tooltip closes. We need access to the tooltip element so we can exclude it when clicking in the ui.