### PR TITLE
fix(tooltip): don't set tooltipRef prop as required

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -106,7 +106,7 @@ Tooltip.propTypes = {
 	tooltipRef: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-	]).isRequired,
+	]),
 	isVisible: PropTypes.bool.isRequired,
 	disablePortal: PropTypes.bool,
 	container: PropTypes.node,


### PR DESCRIPTION
Fix error because of required tooltipRef prop:

<img width="668" alt="image" src="https://user-images.githubusercontent.com/16118473/166708257-4425d486-2fe6-43d7-bee8-e2f52f8f9fa9.png">
