### PR TITLE
fix(tooltip): prevent safari to render own tooltip when ellipsis is set

### DIFF
--- a/src/components/EllipsisWithTooltip/EllipsisWithTooltip.module.scss
+++ b/src/components/EllipsisWithTooltip/EllipsisWithTooltip.module.scss
@@ -4,4 +4,9 @@
 
 .ellipsis__text {
 	display: inline;
+
+	&::after {
+		content: '';
+		display: block;
+	  }
 }


### PR DESCRIPTION
Meer info hier: https://stackoverflow.com/questions/20974276/prevent-safari-from-showing-tooltip-when-text-overflow-is-hidden-with-ellipsis
